### PR TITLE
WIP - ExperimentalFeatures

### DIFF
--- a/pkg/boot/constants.go
+++ b/pkg/boot/constants.go
@@ -6,6 +6,8 @@ const (
 	// OverrideTLSWarningEnvVarName is an environment variable set in BDD tests to override the error (in batch mode)
 	// that is created if TLS is not enabled
 	OverrideTLSWarningEnvVarName = "TESTING_ONLY_OVERRIDE_TLS_WARNING"
+	// OverrideExperimentalFeatureWarningEnvVarName is an environment variable used to disable the experimental feature warning during boot
+	OverrideExperimentalFeatureWarningEnvVarName = "OVERRIDE_EXPERIMENTAL_FEATURE_WARNING"
 	// ConfigBaseRefEnvVarName is the env var name used in the pipeline to reference the base used for the config
 	ConfigBaseRefEnvVarName = "CONFIG_BASE_REF"
 	// ConfigRepoURLEnvVarName is the env var name used in the pipeline to reference the URL of the config

--- a/pkg/cmd/opts/common.go
+++ b/pkg/cmd/opts/common.go
@@ -555,7 +555,7 @@ func (o *CommonOptions) Helm() helm.Helmer {
 			// check helmfile featureflag but default to existing behaviour if there's any issues
 			var helmer helm.Helmer
 			r, _, _ := config.LoadRequirementsConfig("")
-			if r.Helmfile {
+			if r.ExperimentalFeatures.Helmfile.Enabled {
 				helmer = o.NewHelm(false, "helm", true, false)
 			} else {
 				helmer = o.NewHelm(false, "helm3", true, false)

--- a/pkg/cmd/opts/team_settings.go
+++ b/pkg/cmd/opts/team_settings.go
@@ -166,7 +166,7 @@ func (o *CommonOptions) HelmfileModifyDevEnvironment(callback func(env *v1.Envir
 
 // ConfigureCommonOptions lets us configure the common options based on the requirements
 func (o *CommonOptions) ConfigureCommonOptions(requirements *config.RequirementsConfig) error {
-	if requirements.Helmfile {
+	if requirements.ExperimentalFeatures.Helmfile.Enabled {
 		// if using helmfile lets disable eagerly creating the dev Environment and instead lets create that via helm
 		o.ModifyDevEnvironmentFn = o.HelmfileModifyDevEnvironment
 

--- a/pkg/config/install_requirements.go
+++ b/pkg/config/install_requirements.go
@@ -455,6 +455,20 @@ type GithubAppConfig struct {
 	URL string `json:"url,omitempty"`
 }
 
+// ExperimentalFeatures contains experimental features that can be enabled in Jenkins X
+type ExperimentalFeatures struct {
+	// Configuration to enable helmfile
+	Helmfile HelmfileConfig `json:"helmfile,omitempty"`
+}
+
+// ExperimentalFeatures contains experimental features that can be enabled in Jenkins X
+type HelmfileConfig struct {
+	// Indicates if we are using helmfile and helm 3 to spin up environments. This is currently an experimental
+	// feature flag used to implement better Multi-Cluster support. See https://github.com/jenkins-x/jx/issues/6442
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+
 // RequirementsValues contains the logical installation requirements in the `jx-requirements.yml` file as helm values
 type RequirementsValues struct {
 	// RequirementsConfig contains the logical installation requirements
@@ -477,9 +491,6 @@ type RequirementsConfig struct {
 	// GitOps if enabled we will setup a webhook in the boot configuration git repository so that we can
 	// re-run 'jx boot' when changes merge to the master branch
 	GitOps bool `json:"gitops,omitempty"`
-	// Indicates if we are using helmfile and helm 3 to spin up environments. This is currently an experimental
-	// feature flag used to implement better Multi-Cluster support. See https://github.com/jenkins-x/jx/issues/6442
-	Helmfile bool `json:"helmfile,omitempty"`
 	// Kaniko whether to enable kaniko for building docker images
 	Kaniko bool `json:"kaniko,omitempty"`
 	// Ingress contains ingress specific requirements
@@ -500,6 +511,8 @@ type RequirementsConfig struct {
 	VersionStream VersionStreamConfig `json:"versionStream"`
 	// Webhook specifies what engine we should use for webhooks
 	Webhook WebhookType `json:"webhook,omitempty"`
+	// ExperimentalFeatures contains experimental features that can be enabled in Jenkins X
+	ExperimentalFeatures ExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 }
 
 // NewRequirementsConfig creates a default configuration file
@@ -651,7 +664,7 @@ func (c *RequirementsConfig) SaveConfig(fileName string) error {
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}
 
-	if c.Helmfile {
+	if c.ExperimentalFeatures.Helmfile.Enabled {
 		y := RequirementsValues{
 			RequirementsConfig: c,
 		}
@@ -953,7 +966,7 @@ func (c *RequirementsConfig) OverrideRequirementsFromEnvironment(gcloudFn func()
 	}
 	if "" != os.Getenv(RequirementHelmfile) {
 		if envVarBoolean(os.Getenv(RequirementHelmfile)) {
-			c.Helmfile = true
+			c.ExperimentalFeatures.Helmfile.Enabled = true
 		}
 	}
 	if "" != os.Getenv(RequirementKaniko) {


### PR DESCRIPTION
This PR has been opened to further discuss enabling helmfile as an experimental feature until it is ready for production use.  The PR adds an experimentalFeatures section to the jx-requirements.yaml as show below.

```
experimentalFeatures:
  helmfile:
    enabled: true
```

The benefits of this approach is that it: 

- Separates experimental feature configuration out from the main Jenkins X configuration so it is very obvious that the user is configuring a feature that could change in the future. 
- Provides the ability to add extra configuration for the experimental features if needed.
- Provides the ability to add more experimental features that users can enable 
- Warns the user that experimental features have been enabled and prompts the user to abort or continue with the install.

